### PR TITLE
Update pyproject.toml to include gcsfs dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,9 @@ classifiers = [
 ]
 dependencies = [
   "grid-data-models",
-  "fsspec",
-  "requests"
+  "fsspec~=2025.3.2",
+  "gcsfs~=2025.3.2",
+  "requests~=2.32.3"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This can change in the future if we migrate to other storage but for now adding `gcsfs` as dependency here